### PR TITLE
Finish Stealthburner

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,51 @@ These build instructions will reference the following manuals:
 | Manual               | Pages   | Comment
 |----------------------|---------|---
 | Voron Stealthburner  | 1-10    |
-| Voron Stealthburner  | 11      | BigTreeTech supplies an alternative version of this part but i think the stock Voron part works better.
+| Voron Stealthburner  | 11      | BigTreeTech supplies an alternative version of this part but I think the stock Voron part works better.
 | Voron Stealthburner  | 12-13   | Install the heat-set insert, including the two optional ones for the toolhead PCB.
 | Voron Stealthburner  | 14      | This kit will use the [`CW2 Cable Bridge.STL`](https://github.com/bigtreetech/EBB/blob/master/EBB%20SB2240_2209%20CAN/STL/CW2%20Cable%20Bridge.STL) part from the BigTreeTech/EBB repo.  Add two heat-set threaded inserts: ![](images/cw2-cable-bridge-heatset-inserts.png)
 | Voron Stealthburner  | 15-17   | The BMG idler assembly may consist of three/four parts like the Voron manual shows, or it may consists of just two parts. As long as the axle snaps tightly in to the guidler and the gear spins freely and without wobble it's probably ok. If you have problems with the axle popping loose from the guidler, carefully place a drop of cyanoacrylate adhesive (Super glue) in the two places where the axle snaps into the guidler. Be careful not to glue the gear to the axle! ![](/images/BMG-Idler-Assembly-manual.png) ![](/images/BMG-Idler-Assembly-actual.jpg)
+| Voron Stealthburner  | 18      |
+| Voron Stealthburner  | 19 - 20 | You can use the end of the gear shaft to gently press the bearings into place.
+| Voron Stealthburner  | 21      | For this kit this is one solid part so there's nothing to line up.
+| Voron Stealthburner  | 31      | Use the  [`CW2 Cable Bridge.STL`](https://github.com/bigtreetech/EBB/blob/master/EBB%20SB2240_2209%20CAN/STL/CW2%20Cable%20Bridge.STL) that you prepared earlier. The M3x20 screw will be too long. An M3x8 screw will work just fine.
+| Voron Stealthburner  | 34      | Because the PCB will take up a bit more space use [Cable Cover For PCB](https://github.com/bigtreetech/EBB/blob/master/EBB%20SB2240_2209%20CAN/STL/Cable_Cover_For_PCB_V1.1.STL) instead. It is possible to fit the standard one, however the heatsink will be touching the cover.
+| Voron Stealthburner  | 37      | The part you need may not look like the images from the manual. If you use a V6 hotend you won't have the holes at the top.
+| Voron Stealthburner  | 38      | The PCB has an ADXL345 sensor built in so the two additional heat inserts are not needed.
+| Voron Stealthburner  | 39      | If you have a V6 hotend then [this video](https://youtu.be/3eYIfBfV9SI?feature=shared) explains how to set it up.
+| Voron Stealthburner  | 42      | If you have a V6 hotend skip this step.
+| Voron Stealthburner  | 43      | The kit comes with two pieces of PTFE tubing. Use the one with a smaller inner diameter for this part. If you have a V6 hotend then remove the plastic retaining ring, insert the PTFE tube, and then put the ring back in place.
+| Voron Stealthburner  | 49      | You may need to remove some material that's in the way to fully insert the piece.
+| Voron Stealthburner  | 53      | Rotate the fan 90º counter clockwise to have enough wire length to reach the PCB later.
+| Voron Stealthburner  | 54 - 55 | If you have a V6 hotend skip this step.
+| EBB CAN              | 2       | Continue with the CAN manual.
+| EBB CAN              | 3       | The stock fans are all 24V so add the jumper to the right pins.
+| EBB CAN              | 5       | There is no PWM fan so you can forego this step.
+| EBB CAN              | 10      | In this kit it is the final device so plug a jumper to the position highlighted.
+| EBB CAN              | 12      | This kit comes with a different thermistor so skip this step.
+| EBB CAN              | 13      | This kit comes with a PT1000 two wire thermistor. Accordingly, set the switch to 1 - ON, 2 - ON, 3 - OFF, 4 - ON.
+| EBB CAN              | 14      | Mind that the part is rotated in this step.
+| EBB CAN              | 15      | This kit doesn't have a proximity switch so skip this step. 
+| EBB CAN              | 18      | This kit doesn't have BLTouch so skip this step. 
+| EBB CAN              | 20      | You should've already done this in a previous step.
+| EBB CAN              | 21      | The manual calls for an M3x10 screw but the kit doesn't come with any. Use an M3x8 screw instead.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 ### Draw the rest of the owl

--- a/README.md
+++ b/README.md
@@ -172,23 +172,6 @@ These build instructions will reference the following manuals:
 | EBB CAN              | 21      | The manual calls for an M3x10 screw but the kit doesn't come with any. Use an M3x8 screw instead.
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 ### Draw the rest of the owl
 
 | Manual               | Pages   | Comment


### PR DESCRIPTION
This covers the important parts for the build. However, I'm not entirely sure if the CAN cable is correct. The kit comes with two cable sleeves, one soft that's presumably used to shield the cables and one out of plastic that is used for the CAN cable in the images. These can however not be attached to the cable mount that's in the manual and there's no metal wire to support the cable.

At the very least it's possible to work around this and just attach the cable to the ptfe tube or frame extrusion to support it.

